### PR TITLE
Match places to buildings with fuzzy logic

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,258 @@
+# Quick Start Guide
+
+Get your POI table up and running in 3 steps!
+
+## Step 1: Verify Your Data
+
+Run these checks to ensure your Overture Maps tables are ready:
+
+```sql
+-- Check places table
+SELECT COUNT(*) FROM overture_maps_places;
+
+-- Check buildings table  
+SELECT COUNT(*) FROM overture_maps_buildings;
+
+-- Verify geometry types (should be GEOGRAPHY)
+SELECT ST_GEOMETRYTYPE(geometry) FROM overture_maps_places LIMIT 1;
+SELECT ST_GEOMETRYTYPE(geometry) FROM overture_maps_buildings LIMIT 1;
+```
+
+**Expected Results:**
+- Both tables should have data
+- Places should have POINT geometries
+- Buildings should have POLYGON or MULTIPOLYGON geometries
+
+## Step 2: Adjust Configuration (Optional)
+
+Open `create_poi_table.sql` and adjust these parameters if needed:
+
+```sql
+-- Line ~30: Distance threshold in meters
+ST_DWITHIN(p.geometry, b.geometry, 50) -- Change 50 to your preferred distance
+
+-- Line ~95-102: Scoring weights
+(name_similarity_score * 0.6) +        -- 60% for name matching
+(distance_proximity * 0.4) +           -- 40% for distance
+(containment_bonus)                    -- 20 points bonus
+```
+
+**Recommended Starting Values:**
+- **Urban areas:** 25-50 meter distance threshold
+- **Suburban areas:** 50-100 meter distance threshold  
+- **Rural areas:** 100+ meter distance threshold
+
+## Step 3: Run the Script
+
+Execute the main script in your Snowflake worksheet:
+
+```sql
+-- Copy and paste the entire content of create_poi_table.sql
+-- Or use Snowflake's execute file feature
+```
+
+**Expected Runtime:**
+- Small dataset (<10K places): 1-5 minutes
+- Medium dataset (<100K places): 5-15 minutes  
+- Large dataset (>100K places): 15+ minutes
+
+## Step 4: Review Results
+
+Check the automatically generated summary:
+
+```sql
+-- Summary statistics (shown at end of script)
+-- Look for:
+-- - Total POIs
+-- - POIs with building match
+-- - POIs contained in building
+-- - POIs with high name similarity
+
+-- View sample results
+SELECT 
+    place_name,
+    building_name,
+    ROUND(composite_score, 1) AS score
+FROM poi_table
+ORDER BY composite_score DESC
+LIMIT 20;
+```
+
+## Common Issues & Quick Fixes
+
+### Issue: Very few matches (<50%)
+
+**Fix 1:** Increase distance threshold
+```sql
+-- Change from 50 to 100 meters
+ST_DWITHIN(p.geometry, b.geometry, 100)
+```
+
+**Fix 2:** Lower name similarity requirement
+```sql
+-- Line ~115, change from 70 to 50
+name_similarity_score >= 50
+```
+
+### Issue: Many poor quality matches
+
+**Fix 1:** Increase name similarity requirement  
+```sql
+-- Line ~115, change from 70 to 80
+name_similarity_score >= 80
+```
+
+**Fix 2:** Decrease distance threshold
+```sql
+-- Change from 50 to 25 meters
+ST_DWITHIN(p.geometry, b.geometry, 25)
+```
+
+**Fix 3:** Use strict containment approach
+```sql
+-- See poi_matching_config.sql for alternative strategies
+```
+
+### Issue: Script runs too slowly
+
+**Fix 1:** Process in batches by region
+```sql
+-- Add WHERE clause with bounding box
+WHERE ST_WITHIN(p.geometry, 
+    ST_MAKEPOLYGON('LINESTRING(-122.5 37.7, -122.5 37.8, -122.4 37.8, -122.4 37.7, -122.5 37.7)')
+)
+```
+
+**Fix 2:** Increase warehouse size
+```sql
+-- Use larger warehouse temporarily
+USE WAREHOUSE large_warehouse;
+```
+
+**Fix 3:** Test with sample first
+```sql
+-- Test logic on small sample
+CREATE TEMP TABLE sample_places AS 
+SELECT * FROM overture_maps_places LIMIT 5000;
+```
+
+## Understanding the Results
+
+### Composite Score Interpretation
+
+- **90-100:** Excellent match (name matches, spatially contained)
+- **75-89:** Good match (strong name similarity or very close distance)
+- **60-74:** Fair match (moderate name similarity with reasonable distance)
+- **40-59:** Poor match (weak name match or far distance)
+- **<40:** Very poor match (consider excluding)
+
+### Key Metrics to Monitor
+
+```sql
+SELECT 
+    COUNT(*) AS total,
+    ROUND(AVG(composite_score), 1) AS avg_score,
+    ROUND(AVG(name_similarity_score), 1) AS avg_name_sim,
+    ROUND(AVG(distance_meters), 1) AS avg_distance,
+    SUM(CASE WHEN is_contained THEN 1 ELSE 0 END) AS num_contained
+FROM poi_table
+WHERE building_id IS NOT NULL;
+```
+
+**Good Results Indicators:**
+- Average composite score > 75
+- Average name similarity > 60
+- Average distance < 15 meters
+- >30% of POIs contained in buildings
+
+## Next Steps
+
+### Option 1: Use Default Configuration
+If results look good (>70% match rate, avg score >75), you're done!
+
+### Option 2: Fine-tune Parameters
+- Review `poi_matching_config.sql` for alternative strategies
+- Run quality checks from `example_queries.sql`
+- Adjust weights and thresholds based on your data
+
+### Option 3: Custom Approach
+- Use one of the alternative strategies (strict containment, name-priority, nearest)
+- Create your own scoring formula
+- Filter results by specific categories or regions
+
+## Validation Queries
+
+Run these to ensure quality:
+
+```sql
+-- 1. Check for duplicates (should return 0)
+SELECT place_id, COUNT(*) 
+FROM poi_table 
+GROUP BY place_id 
+HAVING COUNT(*) > 1;
+
+-- 2. Review match quality distribution
+SELECT 
+    CASE 
+        WHEN composite_score >= 90 THEN 'Excellent'
+        WHEN composite_score >= 75 THEN 'Good'
+        WHEN composite_score >= 60 THEN 'Fair'
+        ELSE 'Poor'
+    END AS quality,
+    COUNT(*) AS count
+FROM poi_table
+WHERE building_id IS NOT NULL
+GROUP BY quality;
+
+-- 3. Find suspicious matches for manual review
+SELECT * FROM poi_table
+WHERE building_id IS NOT NULL
+  AND composite_score < 50
+ORDER BY composite_score
+LIMIT 20;
+```
+
+## Getting Help
+
+1. **Check the README.md** for detailed documentation
+2. **Run example_queries.sql** for diagnostic queries  
+3. **Review poi_matching_config.sql** for alternative approaches
+4. **Examine your data** - look at actual names and geometries to understand mismatches
+
+## Example Use Cases
+
+### Find all restaurants with building info
+```sql
+SELECT place_name, building_name, addresses
+FROM poi_table
+WHERE categories:primary::STRING = 'restaurant'
+  AND building_id IS NOT NULL;
+```
+
+### Export high-quality matches
+```sql
+SELECT 
+    place_id,
+    place_name,
+    building_id,
+    ST_ASGEOJSON(building_geometry) AS geojson
+FROM poi_table
+WHERE composite_score >= 85;
+```
+
+### Analyze POI density by building
+```sql
+SELECT 
+    building_id,
+    building_name,
+    COUNT(*) AS num_pois
+FROM poi_table
+WHERE building_id IS NOT NULL
+GROUP BY building_id, building_name
+HAVING COUNT(*) >= 3
+ORDER BY num_pois DESC;
+```
+
+---
+
+**Ready to start?** Open `create_poi_table.sql` and run it in Snowflake! 🚀

--- a/README.md
+++ b/README.md
@@ -1,0 +1,265 @@
+# POI Table Creation: Overture Maps Places + Buildings Matching
+
+This solution matches Overture Maps places (points) to buildings (polygons) using spatial proximity and fuzzy name matching to create a comprehensive POI (Point of Interest) table.
+
+## Overview
+
+The solution handles the common challenge where:
+- A single place point might overlap with multiple building polygons
+- Building and place names might not match exactly
+- Some places might not be contained within any building polygon
+
+## Files
+
+### 1. `create_poi_table.sql`
+Main script that creates the POI table with the best building match for each place.
+
+**Key Features:**
+- Spatial matching using `ST_CONTAINS` and `ST_DWITHIN`
+- Fuzzy name matching using `JAROWINKLER_SIMILARITY`
+- Composite scoring combining:
+  - Name similarity (60% weight)
+  - Spatial proximity (40% weight)
+  - Containment bonus (20 points)
+- Ranks matches and selects the best one per place
+- Includes places with no building matches (optional)
+
+### 2. `poi_matching_config.sql`
+Configuration options and alternative matching strategies.
+
+**Includes:**
+- Configurable parameters (distance thresholds, weights)
+- Alternative Strategy 1: Strict spatial containment only
+- Alternative Strategy 2: Name-prioritized matching
+- Alternative Strategy 3: Nearest building (spatial only)
+- Quality validation views
+- Performance optimization tips
+
+## Prerequisites
+
+Your Snowflake database should have:
+- `overture_maps_places` table with columns:
+  - `id` (place identifier)
+  - `names` (VARIANT/JSON with name data)
+  - `geometry` (GEOGRAPHY point)
+  - `categories`, `confidence`, `websites`, `socials`, `emails`, `phones`, `addresses`, `sources`
+
+- `overture_maps_buildings` table with columns:
+  - `id` (building identifier)
+  - `names` (VARIANT/JSON with name data)
+  - `geometry` (GEOGRAPHY polygon)
+
+## Usage
+
+### Basic Usage
+
+1. **Run the main script:**
+```sql
+-- Execute create_poi_table.sql
+-- This will create the poi_table with best matches
+```
+
+2. **Review the results:**
+```sql
+SELECT * FROM poi_table LIMIT 100;
+```
+
+3. **Check the summary statistics** (automatically displayed at the end of the script)
+
+### Customization
+
+#### Adjust Distance Threshold
+
+Change line in `create_poi_table.sql`:
+```sql
+ST_DWITHIN(p.geometry, b.geometry, 50) -- Change 50 to desired meters
+```
+
+#### Adjust Scoring Weights
+
+Modify the composite score calculation:
+```sql
+(
+    (name_similarity_score * 0.6) +  -- Change 0.6 for name weight
+    (CASE 
+        WHEN distance_meters = 0 THEN 40  -- Change 40 for distance weight
+        ELSE GREATEST(0, 40 * (1 - (distance_meters / 50)))
+     END) +
+    (CASE WHEN is_contained THEN 20 ELSE 0 END)  -- Change 20 for containment bonus
+)
+```
+
+#### Change Name Matching Threshold
+
+Adjust the WHERE clause in Step 3:
+```sql
+WHERE 
+    (
+        is_contained = TRUE OR 
+        distance_meters <= 25 OR 
+        name_similarity_score >= 70  -- Change 70 to desired threshold
+    )
+```
+
+### Alternative Approaches
+
+If the default approach doesn't work well for your data:
+
+1. **Strict Containment Only** - Use if you only want places inside buildings
+2. **Name-Prioritized** - Use if name matching is more important than distance
+3. **Nearest Building** - Use if you want purely spatial matching
+
+See `poi_matching_config.sql` for these alternatives.
+
+## Schema Details
+
+### Output Table: `poi_table`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `place_id` | VARCHAR | Place identifier |
+| `place_names` | VARIANT | Place name data (JSON) |
+| `place_name` | VARCHAR | Primary place name (extracted) |
+| `categories` | VARIANT | Place categories |
+| `confidence` | FLOAT | Confidence score |
+| `websites` | VARIANT | Website URLs |
+| `socials` | VARIANT | Social media links |
+| `emails` | VARIANT | Email addresses |
+| `phones` | VARIANT | Phone numbers |
+| `addresses` | VARIANT | Address information |
+| `sources` | VARIANT | Data sources |
+| `place_geometry` | GEOGRAPHY | Place point geometry |
+| `building_id` | VARCHAR | Matched building identifier |
+| `building_names` | VARIANT | Building name data (JSON) |
+| `building_name` | VARCHAR | Primary building name (extracted) |
+| `building_geometry` | GEOGRAPHY | Building polygon geometry |
+| `is_contained` | BOOLEAN | Whether place is inside building |
+| `distance_meters` | FLOAT | Distance to building (meters) |
+| `distance_to_centroid` | FLOAT | Distance to building center |
+| `name_similarity_score` | FLOAT | Name match score (0-100) |
+| `edit_distance` | INTEGER | Edit distance between names |
+| `composite_score` | FLOAT | Overall match quality score |
+| `created_at` | TIMESTAMP | Record creation timestamp |
+
+## Quality Validation
+
+### Check Matching Quality
+
+```sql
+-- View quality distribution
+SELECT * FROM matching_quality_report;
+
+-- Find potential mismatches
+SELECT * FROM potential_mismatches;
+
+-- See places with multiple candidate buildings
+SELECT * FROM places_with_multiple_matches LIMIT 100;
+```
+
+### Common Adjustments Based on Results
+
+**If too many places have no matches:**
+- Increase distance threshold (e.g., from 50m to 100m)
+- Lower name similarity threshold (e.g., from 70 to 60)
+
+**If matches seem inaccurate:**
+- Increase name similarity threshold
+- Adjust scoring weights to favor name matching
+- Use strict containment strategy
+
+**If multiple buildings match the same place:**
+- The script automatically picks the best one based on composite score
+- Review `places_with_multiple_matches` view to see alternatives
+
+## Performance Considerations
+
+For large datasets:
+
+1. **Add spatial clustering:**
+```sql
+ALTER TABLE poi_table CLUSTER BY (LINEAR(ST_X(place_geometry), ST_Y(place_geometry)));
+```
+
+2. **Use search optimization:**
+```sql
+ALTER TABLE poi_table ADD SEARCH OPTIMIZATION;
+```
+
+3. **Consider processing in batches** by geographic region:
+```sql
+-- Example: Process by bounding box
+WHERE ST_WITHIN(p.geometry, ST_MAKEPOLYGON('LINESTRING(...)'))
+```
+
+## Troubleshooting
+
+### Issue: Names extraction returns NULL
+**Solution:** Check your `names` VARIANT structure:
+```sql
+SELECT names FROM overture_maps_places LIMIT 5;
+```
+Adjust the name extraction logic based on your schema.
+
+### Issue: All distances are NULL
+**Solution:** Ensure geometries are GEOGRAPHY type, not GEOMETRY:
+```sql
+ALTER TABLE overture_maps_places 
+ALTER COLUMN geometry SET DATA TYPE GEOGRAPHY;
+```
+
+### Issue: Query times out
+**Solution:** 
+- Add WHERE clause to process subset of data
+- Increase warehouse size
+- Process in geographic batches
+
+## Example Queries
+
+### Find high-confidence matches
+```sql
+SELECT 
+    place_name,
+    building_name,
+    composite_score,
+    distance_meters
+FROM poi_table
+WHERE composite_score >= 90
+ORDER BY composite_score DESC
+LIMIT 100;
+```
+
+### Find places in specific category
+```sql
+SELECT 
+    place_name,
+    building_name,
+    categories
+FROM poi_table
+WHERE categories:primary::STRING = 'restaurant'
+  AND building_id IS NOT NULL;
+```
+
+### Export for analysis
+```sql
+SELECT 
+    place_id,
+    place_name,
+    building_id,
+    ST_ASGEOJSON(building_geometry) AS building_geojson,
+    composite_score
+FROM poi_table
+WHERE composite_score >= 80;
+```
+
+## Notes
+
+- The script creates temporary tables during processing which are automatically cleaned up
+- Duplicate place_ids in the final table should not occur (each place matched to at most one building)
+- NULL building_id indicates no suitable building match was found
+- Adjust thresholds based on your data quality and matching requirements
+
+## Support
+
+For issues or questions about:
+- Overture Maps data schema: https://docs.overturemaps.org/
+- Snowflake spatial functions: https://docs.snowflake.com/en/sql-reference/functions-geospatial

--- a/create_poi_table.sql
+++ b/create_poi_table.sql
@@ -1,0 +1,263 @@
+-- ============================================================================
+-- POI Table Creation: Overture Maps Places + Buildings Spatial Matching
+-- ============================================================================
+-- This script matches places (points) to buildings (polygons) using:
+-- 1. Spatial containment/proximity
+-- 2. Fuzzy name matching
+-- 3. Distance to nearest building
+-- ============================================================================
+
+-- Step 1: Find all candidate matches (places within or near buildings)
+-- Adjust the distance threshold as needed (e.g., 50 meters for nearby matches)
+CREATE OR REPLACE TEMPORARY TABLE candidate_matches AS
+SELECT 
+    p.id AS place_id,
+    p.names,
+    p.categories,
+    p.confidence,
+    p.websites,
+    p.socials,
+    p.emails,
+    p.phones,
+    p.addresses,
+    p.sources,
+    p.geometry AS place_geometry,
+    
+    b.id AS building_id,
+    b.names AS building_names,
+    b.geometry AS building_geometry,
+    
+    -- Check if place is within building
+    ST_CONTAINS(b.geometry, p.geometry) AS is_contained,
+    
+    -- Calculate distance from place point to building boundary
+    ST_DISTANCE(p.geometry, b.geometry) AS distance_meters,
+    
+    -- Calculate distance to building centroid (alternative metric)
+    ST_DISTANCE(p.geometry, ST_CENTROID(b.geometry)) AS distance_to_centroid
+    
+FROM overture_maps_places p
+CROSS JOIN overture_maps_buildings b
+WHERE 
+    -- Spatial filter: only consider buildings within reasonable distance
+    -- ST_DWITHIN uses meters for geography type
+    ST_DWITHIN(p.geometry, b.geometry, 50) -- 50 meter threshold
+;
+
+-- Step 2: Calculate name similarity scores
+CREATE OR REPLACE TEMPORARY TABLE scored_matches AS
+SELECT 
+    cm.*,
+    
+    -- Extract primary place name (assuming names is a VARIANT/JSON with 'primary' field)
+    -- Adjust based on your actual schema
+    COALESCE(
+        cm.names:primary::STRING,
+        cm.names:common[0].value::STRING,
+        cm.names[0].value::STRING,
+        ''
+    ) AS place_name,
+    
+    -- Extract primary building name
+    COALESCE(
+        cm.building_names:primary::STRING,
+        cm.building_names:common[0].value::STRING,
+        cm.building_names[0].value::STRING,
+        ''
+    ) AS building_name,
+    
+    -- Fuzzy name matching using Jaro-Winkler similarity (0-100 scale)
+    CASE 
+        WHEN place_name = '' OR building_name = '' THEN 0
+        ELSE JAROWINKLER_SIMILARITY(
+            UPPER(TRIM(place_name)), 
+            UPPER(TRIM(building_name))
+        )
+    END AS name_similarity_score,
+    
+    -- Alternative: Edit distance (lower is better)
+    CASE 
+        WHEN place_name = '' OR building_name = '' THEN 999
+        ELSE EDITDISTANCE(
+            UPPER(TRIM(place_name)), 
+            UPPER(TRIM(building_name))
+        )
+    END AS edit_distance,
+    
+    -- Composite score: balance spatial proximity and name similarity
+    -- Weight factors (adjust as needed):
+    -- - 60% name similarity (0-100 scale)
+    -- - 40% proximity (inverse of distance, normalized)
+    -- - Bonus for containment
+    (
+        (name_similarity_score * 0.6) +
+        (CASE 
+            WHEN distance_meters = 0 THEN 40
+            ELSE GREATEST(0, 40 * (1 - (distance_meters / 50)))
+         END) +
+        (CASE WHEN is_contained THEN 20 ELSE 0 END)
+    ) AS composite_score
+    
+FROM candidate_matches cm
+;
+
+-- Step 3: Rank matches for each place and select the best one
+CREATE OR REPLACE TEMPORARY TABLE ranked_matches AS
+SELECT 
+    *,
+    ROW_NUMBER() OVER (
+        PARTITION BY place_id 
+        ORDER BY 
+            composite_score DESC,
+            is_contained DESC,
+            distance_meters ASC,
+            name_similarity_score DESC
+    ) AS match_rank
+FROM scored_matches
+WHERE 
+    -- Optional filters:
+    -- Only keep reasonable matches (adjust thresholds as needed)
+    (
+        is_contained = TRUE OR 
+        distance_meters <= 25 OR 
+        name_similarity_score >= 70
+    )
+;
+
+-- Step 4: Create final POI table with best matches
+CREATE OR REPLACE TABLE poi_table AS
+SELECT 
+    -- Place information
+    place_id,
+    names AS place_names,
+    place_name,
+    categories,
+    confidence,
+    websites,
+    socials,
+    emails,
+    phones,
+    addresses,
+    sources,
+    place_geometry,
+    
+    -- Matched building information
+    building_id,
+    building_names,
+    building_name,
+    building_geometry,
+    
+    -- Match quality metrics
+    is_contained,
+    distance_meters,
+    distance_to_centroid,
+    name_similarity_score,
+    edit_distance,
+    composite_score,
+    
+    -- Metadata
+    CURRENT_TIMESTAMP() AS created_at
+    
+FROM ranked_matches
+WHERE match_rank = 1  -- Only keep the best match per place
+;
+
+-- Step 5: Add places with no building matches (optional)
+-- If you want to include places that didn't match any building
+INSERT INTO poi_table
+SELECT 
+    p.id AS place_id,
+    p.names AS place_names,
+    COALESCE(
+        p.names:primary::STRING,
+        p.names:common[0].value::STRING,
+        p.names[0].value::STRING
+    ) AS place_name,
+    p.categories,
+    p.confidence,
+    p.websites,
+    p.socials,
+    p.emails,
+    p.phones,
+    p.addresses,
+    p.sources,
+    p.geometry AS place_geometry,
+    
+    NULL AS building_id,
+    NULL AS building_names,
+    NULL AS building_name,
+    NULL AS building_geometry,
+    
+    FALSE AS is_contained,
+    NULL AS distance_meters,
+    NULL AS distance_to_centroid,
+    0 AS name_similarity_score,
+    999 AS edit_distance,
+    0 AS composite_score,
+    
+    CURRENT_TIMESTAMP() AS created_at
+    
+FROM overture_maps_places p
+WHERE NOT EXISTS (
+    SELECT 1 FROM ranked_matches rm 
+    WHERE rm.place_id = p.id AND rm.match_rank = 1
+)
+;
+
+-- ============================================================================
+-- Summary Statistics
+-- ============================================================================
+SELECT 
+    'Total POIs' AS metric,
+    COUNT(*) AS count
+FROM poi_table
+
+UNION ALL
+
+SELECT 
+    'POIs with building match' AS metric,
+    COUNT(*) AS count
+FROM poi_table
+WHERE building_id IS NOT NULL
+
+UNION ALL
+
+SELECT 
+    'POIs contained in building' AS metric,
+    COUNT(*) AS count
+FROM poi_table
+WHERE is_contained = TRUE
+
+UNION ALL
+
+SELECT 
+    'POIs with high name similarity (>=80)' AS metric,
+    COUNT(*) AS count
+FROM poi_table
+WHERE name_similarity_score >= 80
+
+UNION ALL
+
+SELECT 
+    'POIs with no building match' AS metric,
+    COUNT(*) AS count
+FROM poi_table
+WHERE building_id IS NULL
+;
+
+-- ============================================================================
+-- Sample output to verify results
+-- ============================================================================
+SELECT 
+    place_id,
+    place_name,
+    building_id,
+    building_name,
+    is_contained,
+    ROUND(distance_meters, 2) AS dist_m,
+    ROUND(name_similarity_score, 2) AS name_sim,
+    ROUND(composite_score, 2) AS score
+FROM poi_table
+WHERE building_id IS NOT NULL
+ORDER BY composite_score DESC
+LIMIT 100;

--- a/example_queries.sql
+++ b/example_queries.sql
@@ -1,0 +1,350 @@
+-- ============================================================================
+-- Example Queries and Testing for POI Table Creation
+-- ============================================================================
+-- Use these queries to verify your setup and test the matching logic
+-- ============================================================================
+
+-- ============================================================================
+-- PART 1: Pre-flight Checks
+-- ============================================================================
+
+-- 1. Verify places table exists and has data
+SELECT 
+    COUNT(*) AS total_places,
+    COUNT(DISTINCT id) AS unique_places,
+    COUNT(geometry) AS places_with_geometry,
+    COUNT(names) AS places_with_names
+FROM overture_maps_places;
+
+-- 2. Verify buildings table exists and has data
+SELECT 
+    COUNT(*) AS total_buildings,
+    COUNT(DISTINCT id) AS unique_buildings,
+    COUNT(geometry) AS buildings_with_geometry,
+    COUNT(names) AS buildings_with_names
+FROM overture_maps_buildings;
+
+-- 3. Check geometry types
+SELECT 
+    ST_GEOMETRYTYPE(geometry) AS geom_type,
+    COUNT(*) AS count
+FROM overture_maps_places
+GROUP BY geom_type;
+
+SELECT 
+    ST_GEOMETRYTYPE(geometry) AS geom_type,
+    COUNT(*) AS count
+FROM overture_maps_buildings
+GROUP BY geom_type;
+
+-- 4. Examine names structure (important for name extraction)
+SELECT 
+    id,
+    names,
+    names:primary::STRING AS primary_name,
+    names:common[0].value::STRING AS common_name_0,
+    names:common::ARRAY AS all_common_names
+FROM overture_maps_places
+LIMIT 10;
+
+SELECT 
+    id,
+    names,
+    names:primary::STRING AS primary_name
+FROM overture_maps_buildings
+WHERE names IS NOT NULL
+LIMIT 10;
+
+-- 5. Check spatial distribution (sample bounding box)
+SELECT 
+    ST_XMIN(ST_ENVELOPE_AGG(geometry)) AS min_longitude,
+    ST_XMAX(ST_ENVELOPE_AGG(geometry)) AS max_longitude,
+    ST_YMIN(ST_ENVELOPE_AGG(geometry)) AS min_latitude,
+    ST_YMAX(ST_ENVELOPE_AGG(geometry)) AS max_latitude
+FROM overture_maps_places;
+
+-- ============================================================================
+-- PART 2: Test on Small Sample
+-- ============================================================================
+
+-- Test the matching logic on a small sample (faster for development)
+CREATE OR REPLACE TEMPORARY TABLE sample_places AS
+SELECT * FROM overture_maps_places LIMIT 1000;
+
+CREATE OR REPLACE TEMPORARY TABLE sample_buildings AS
+SELECT b.* 
+FROM overture_maps_buildings b
+INNER JOIN sample_places p
+    ON ST_DWITHIN(p.geometry, b.geometry, 100)
+;
+
+-- Now test with samples (replace table names in main script temporarily)
+SELECT 
+    p.id AS place_id,
+    p.names:primary::STRING AS place_name,
+    b.id AS building_id,
+    b.names:primary::STRING AS building_name,
+    ST_CONTAINS(b.geometry, p.geometry) AS contained,
+    ST_DISTANCE(p.geometry, b.geometry) AS distance,
+    JAROWINKLER_SIMILARITY(
+        UPPER(COALESCE(p.names:primary::STRING, '')),
+        UPPER(COALESCE(b.names:primary::STRING, ''))
+    ) AS name_similarity
+FROM sample_places p
+CROSS JOIN sample_buildings b
+WHERE ST_DWITHIN(p.geometry, b.geometry, 50)
+LIMIT 100;
+
+-- ============================================================================
+-- PART 3: Analyze Results After Running Main Script
+-- ============================================================================
+
+-- Basic statistics
+SELECT 
+    COUNT(*) AS total_pois,
+    COUNT(building_id) AS matched_pois,
+    COUNT(*) - COUNT(building_id) AS unmatched_pois,
+    ROUND(100.0 * COUNT(building_id) / COUNT(*), 2) AS match_rate_pct
+FROM poi_table;
+
+-- Distribution of match quality
+SELECT 
+    CASE 
+        WHEN building_id IS NULL THEN '0. No Match'
+        WHEN composite_score >= 95 THEN '1. Excellent (95+)'
+        WHEN composite_score >= 85 THEN '2. Very Good (85-94)'
+        WHEN composite_score >= 75 THEN '3. Good (75-84)'
+        WHEN composite_score >= 60 THEN '4. Fair (60-74)'
+        WHEN composite_score >= 40 THEN '5. Poor (40-59)'
+        ELSE '6. Very Poor (<40)'
+    END AS quality_tier,
+    COUNT(*) AS count,
+    ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 2) AS pct
+FROM poi_table
+GROUP BY quality_tier
+ORDER BY quality_tier;
+
+-- Top matches by score
+SELECT 
+    place_name,
+    building_name,
+    is_contained,
+    ROUND(distance_meters, 2) AS dist_m,
+    ROUND(name_similarity_score, 1) AS name_sim,
+    ROUND(composite_score, 1) AS score
+FROM poi_table
+WHERE building_id IS NOT NULL
+ORDER BY composite_score DESC
+LIMIT 50;
+
+-- Problematic matches (for review)
+SELECT 
+    place_name,
+    building_name,
+    is_contained,
+    ROUND(distance_meters, 2) AS dist_m,
+    ROUND(name_similarity_score, 1) AS name_sim,
+    ROUND(composite_score, 1) AS score
+FROM poi_table
+WHERE building_id IS NOT NULL
+  AND composite_score < 60
+ORDER BY composite_score ASC
+LIMIT 50;
+
+-- Places with very different names but spatial match
+SELECT 
+    place_name,
+    building_name,
+    is_contained,
+    ROUND(distance_meters, 2) AS dist_m,
+    ROUND(name_similarity_score, 1) AS name_sim,
+    ROUND(composite_score, 1) AS score
+FROM poi_table
+WHERE building_id IS NOT NULL
+  AND distance_meters < 10
+  AND name_similarity_score < 50
+LIMIT 50;
+
+-- ============================================================================
+-- PART 4: Category Analysis
+-- ============================================================================
+
+-- Match rate by place category
+SELECT 
+    categories:primary::STRING AS category,
+    COUNT(*) AS total,
+    COUNT(building_id) AS matched,
+    ROUND(100.0 * COUNT(building_id) / COUNT(*), 1) AS match_pct,
+    ROUND(AVG(CASE WHEN building_id IS NOT NULL THEN composite_score END), 1) AS avg_score
+FROM poi_table
+GROUP BY category
+HAVING COUNT(*) >= 10
+ORDER BY total DESC
+LIMIT 30;
+
+-- ============================================================================
+-- PART 5: Spatial Analysis
+-- ============================================================================
+
+-- Distance distribution for matched POIs
+SELECT 
+    CASE 
+        WHEN distance_meters = 0 THEN '0m (Boundary)'
+        WHEN distance_meters <= 5 THEN '0-5m'
+        WHEN distance_meters <= 10 THEN '5-10m'
+        WHEN distance_meters <= 20 THEN '10-20m'
+        WHEN distance_meters <= 30 THEN '20-30m'
+        WHEN distance_meters <= 50 THEN '30-50m'
+        ELSE '>50m'
+    END AS distance_range,
+    COUNT(*) AS count,
+    ROUND(AVG(composite_score), 1) AS avg_score,
+    ROUND(AVG(name_similarity_score), 1) AS avg_name_sim
+FROM poi_table
+WHERE building_id IS NOT NULL
+GROUP BY distance_range
+ORDER BY 
+    CASE distance_range
+        WHEN '0m (Boundary)' THEN 1
+        WHEN '0-5m' THEN 2
+        WHEN '5-10m' THEN 3
+        WHEN '10-20m' THEN 4
+        WHEN '20-30m' THEN 5
+        WHEN '30-50m' THEN 6
+        ELSE 7
+    END;
+
+-- Containment analysis
+SELECT 
+    is_contained,
+    COUNT(*) AS count,
+    ROUND(AVG(distance_meters), 2) AS avg_distance,
+    ROUND(AVG(name_similarity_score), 1) AS avg_name_sim,
+    ROUND(AVG(composite_score), 1) AS avg_composite_score
+FROM poi_table
+WHERE building_id IS NOT NULL
+GROUP BY is_contained;
+
+-- ============================================================================
+-- PART 6: Data Quality Checks
+-- ============================================================================
+
+-- Check for duplicate place_ids (should be 0)
+SELECT 
+    'Duplicate place_ids' AS check_name,
+    COUNT(*) AS issue_count
+FROM (
+    SELECT place_id, COUNT(*) AS cnt
+    FROM poi_table
+    GROUP BY place_id
+    HAVING cnt > 1
+);
+
+-- Check for NULL geometries
+SELECT 
+    'NULL place geometries' AS check_name,
+    COUNT(*) AS issue_count
+FROM poi_table
+WHERE place_geometry IS NULL
+
+UNION ALL
+
+SELECT 
+    'NULL building geometries (where matched)' AS check_name,
+    COUNT(*) AS issue_count
+FROM poi_table
+WHERE building_id IS NOT NULL 
+  AND building_geometry IS NULL;
+
+-- Check for unrealistic distances (possible data issues)
+SELECT 
+    place_id,
+    place_name,
+    building_name,
+    distance_meters,
+    is_contained
+FROM poi_table
+WHERE building_id IS NOT NULL
+  AND distance_meters > 100  -- Should not happen with 50m threshold
+LIMIT 20;
+
+-- ============================================================================
+-- PART 7: Export Examples
+-- ============================================================================
+
+-- Export high-quality matches as GeoJSON
+SELECT 
+    OBJECT_CONSTRUCT(
+        'type', 'Feature',
+        'properties', OBJECT_CONSTRUCT(
+            'place_id', place_id,
+            'place_name', place_name,
+            'building_id', building_id,
+            'building_name', building_name,
+            'composite_score', composite_score,
+            'match_quality', 
+                CASE 
+                    WHEN composite_score >= 90 THEN 'excellent'
+                    WHEN composite_score >= 75 THEN 'good'
+                    ELSE 'fair'
+                END
+        ),
+        'geometry', PARSE_JSON(ST_ASGEOJSON(place_geometry))
+    ) AS geojson_feature
+FROM poi_table
+WHERE building_id IS NOT NULL
+  AND composite_score >= 75
+LIMIT 1000;
+
+-- Export building polygons with matched POIs
+SELECT 
+    building_id,
+    building_name,
+    COUNT(*) AS num_pois_in_building,
+    ARRAY_AGG(place_name) AS place_names,
+    ST_ASGEOJSON(ANY_VALUE(building_geometry)) AS building_geojson
+FROM poi_table
+WHERE building_id IS NOT NULL
+  AND is_contained = TRUE
+GROUP BY building_id, building_name
+HAVING COUNT(*) >= 2  -- Buildings with multiple POIs
+ORDER BY num_pois_in_building DESC
+LIMIT 100;
+
+-- ============================================================================
+-- PART 8: Performance Testing
+-- ============================================================================
+
+-- Check table sizes
+SELECT 
+    'poi_table' AS table_name,
+    COUNT(*) AS row_count,
+    SUM(LENGTH(TO_JSON(OBJECT_CONSTRUCT(*)))) AS approx_size_bytes
+FROM poi_table
+
+UNION ALL
+
+SELECT 
+    'overture_maps_places' AS table_name,
+    COUNT(*) AS row_count,
+    SUM(LENGTH(TO_JSON(OBJECT_CONSTRUCT(*)))) AS approx_size_bytes
+FROM overture_maps_places
+
+UNION ALL
+
+SELECT 
+    'overture_maps_buildings' AS table_name,
+    COUNT(*) AS row_count,
+    SUM(LENGTH(TO_JSON(OBJECT_CONSTRUCT(*)))) AS approx_size_bytes
+FROM overture_maps_buildings;
+
+-- Check query performance (add EXPLAIN if needed)
+SELECT 
+    place_name,
+    building_name,
+    composite_score
+FROM poi_table
+WHERE ST_DWITHIN(place_geometry, ST_MAKEPOINT(-122.4194, 37.7749), 1000)
+  AND composite_score >= 80
+ORDER BY composite_score DESC
+LIMIT 100;

--- a/poi_matching_config.sql
+++ b/poi_matching_config.sql
@@ -1,0 +1,266 @@
+-- ============================================================================
+-- POI Matching Configuration Guide
+-- ============================================================================
+-- This file contains configurable parameters and alternative approaches
+-- for the POI matching process
+-- ============================================================================
+
+-- ============================================================================
+-- CONFIGURATION PARAMETERS
+-- ============================================================================
+
+-- Distance Threshold (meters)
+-- How far from a building should we still consider it a match?
+SET distance_threshold = 50;  -- Adjust: 25, 50, 100 meters
+
+-- Name Similarity Threshold
+-- Minimum Jaro-Winkler score to consider a name match (0-100 scale)
+SET name_similarity_threshold = 70;  -- Adjust: 60, 70, 80
+
+-- Scoring Weights (should sum to ~100)
+SET weight_name_similarity = 60;      -- 60% weight on name matching
+SET weight_spatial_proximity = 40;    -- 40% weight on distance
+SET bonus_containment = 20;           -- Bonus points for spatial containment
+
+-- ============================================================================
+-- ALTERNATIVE MATCHING STRATEGY 1: Strict Spatial Containment
+-- ============================================================================
+-- Use this if you only want places that are actually inside buildings
+
+CREATE OR REPLACE TABLE poi_table_strict AS
+WITH spatial_matches AS (
+    SELECT 
+        p.*,
+        b.id AS building_id,
+        b.names AS building_names,
+        b.geometry AS building_geometry,
+        ST_DISTANCE(p.geometry, ST_CENTROID(b.geometry)) AS distance_to_center
+    FROM overture_maps_places p
+    INNER JOIN overture_maps_buildings b
+        ON ST_CONTAINS(b.geometry, p.geometry)
+)
+SELECT 
+    *,
+    ROW_NUMBER() OVER (
+        PARTITION BY id 
+        ORDER BY distance_to_center ASC
+    ) AS rank
+FROM spatial_matches
+QUALIFY rank = 1;
+
+-- ============================================================================
+-- ALTERNATIVE MATCHING STRATEGY 2: Name-Prioritized Matching
+-- ============================================================================
+-- Use this if name matching is more important than spatial proximity
+
+CREATE OR REPLACE TABLE poi_table_name_priority AS
+WITH name_matches AS (
+    SELECT 
+        p.id AS place_id,
+        p.names,
+        COALESCE(p.names:primary::STRING, '') AS place_name,
+        p.geometry AS place_geometry,
+        p.categories,
+        p.confidence,
+        p.websites,
+        p.socials,
+        p.emails,
+        p.phones,
+        p.addresses,
+        
+        b.id AS building_id,
+        b.names AS building_names,
+        COALESCE(b.names:primary::STRING, '') AS building_name,
+        b.geometry AS building_geometry,
+        
+        JAROWINKLER_SIMILARITY(
+            UPPER(TRIM(COALESCE(p.names:primary::STRING, ''))),
+            UPPER(TRIM(COALESCE(b.names:primary::STRING, '')))
+        ) AS name_score,
+        
+        ST_DISTANCE(p.geometry, b.geometry) AS distance
+        
+    FROM overture_maps_places p
+    CROSS JOIN overture_maps_buildings b
+    WHERE ST_DWITHIN(p.geometry, b.geometry, 100)
+      AND name_score >= 75  -- High name similarity required
+),
+ranked AS (
+    SELECT 
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY place_id 
+            ORDER BY name_score DESC, distance ASC
+        ) AS rank
+    FROM name_matches
+)
+SELECT * FROM ranked WHERE rank = 1;
+
+-- ============================================================================
+-- ALTERNATIVE MATCHING STRATEGY 3: Nearest Building (Spatial Only)
+-- ============================================================================
+-- Use this if you want to match each place to its nearest building regardless of name
+
+CREATE OR REPLACE TABLE poi_table_nearest AS
+WITH nearest_building AS (
+    SELECT 
+        p.id AS place_id,
+        p.names AS place_names,
+        p.geometry AS place_geometry,
+        p.categories,
+        p.confidence,
+        p.websites,
+        p.socials,
+        p.emails,
+        p.phones,
+        p.addresses,
+        
+        b.id AS building_id,
+        b.names AS building_names,
+        b.geometry AS building_geometry,
+        
+        ST_DISTANCE(p.geometry, b.geometry) AS distance,
+        ST_CONTAINS(b.geometry, p.geometry) AS is_contained,
+        
+        ROW_NUMBER() OVER (
+            PARTITION BY p.id 
+            ORDER BY 
+                ST_CONTAINS(b.geometry, p.geometry) DESC,
+                ST_DISTANCE(p.geometry, b.geometry) ASC
+        ) AS rank
+        
+    FROM overture_maps_places p
+    CROSS JOIN overture_maps_buildings b
+    WHERE ST_DWITHIN(p.geometry, b.geometry, 100)
+)
+SELECT * FROM nearest_building WHERE rank = 1;
+
+-- ============================================================================
+-- UTILITY: Check for places with multiple building matches
+-- ============================================================================
+
+CREATE OR REPLACE VIEW places_with_multiple_matches AS
+SELECT 
+    place_id,
+    place_name,
+    COUNT(*) AS num_candidate_buildings,
+    ARRAY_AGG(
+        OBJECT_CONSTRUCT(
+            'building_id', building_id,
+            'building_name', building_name,
+            'distance', distance_meters,
+            'name_similarity', name_similarity_score,
+            'composite_score', composite_score
+        )
+    ) AS candidates
+FROM scored_matches  -- References temp table from main script
+GROUP BY place_id, place_name
+HAVING COUNT(*) > 1
+ORDER BY num_candidate_buildings DESC;
+
+-- ============================================================================
+-- UTILITY: Validate matching quality
+-- ============================================================================
+
+CREATE OR REPLACE VIEW matching_quality_report AS
+SELECT 
+    CASE 
+        WHEN composite_score >= 90 THEN 'Excellent (90+)'
+        WHEN composite_score >= 75 THEN 'Good (75-89)'
+        WHEN composite_score >= 60 THEN 'Fair (60-74)'
+        WHEN composite_score >= 40 THEN 'Poor (40-59)'
+        ELSE 'Very Poor (<40)'
+    END AS quality_tier,
+    
+    COUNT(*) AS num_pois,
+    
+    ROUND(AVG(name_similarity_score), 2) AS avg_name_similarity,
+    ROUND(AVG(distance_meters), 2) AS avg_distance,
+    
+    SUM(CASE WHEN is_contained THEN 1 ELSE 0 END) AS num_contained,
+    SUM(CASE WHEN distance_meters <= 10 THEN 1 ELSE 0 END) AS num_within_10m,
+    SUM(CASE WHEN name_similarity_score >= 80 THEN 1 ELSE 0 END) AS num_name_match_80plus
+    
+FROM poi_table
+WHERE building_id IS NOT NULL
+GROUP BY quality_tier
+ORDER BY 
+    CASE quality_tier
+        WHEN 'Excellent (90+)' THEN 1
+        WHEN 'Good (75-89)' THEN 2
+        WHEN 'Fair (60-74)' THEN 3
+        WHEN 'Poor (40-59)' THEN 4
+        ELSE 5
+    END;
+
+-- ============================================================================
+-- UTILITY: Find potential mismatches for manual review
+-- ============================================================================
+
+CREATE OR REPLACE VIEW potential_mismatches AS
+SELECT 
+    place_id,
+    place_name,
+    building_id,
+    building_name,
+    distance_meters,
+    name_similarity_score,
+    composite_score,
+    is_contained
+FROM poi_table
+WHERE building_id IS NOT NULL
+  AND (
+      -- Low composite score
+      composite_score < 50 OR
+      -- Name mismatch with spatial proximity
+      (distance_meters < 5 AND name_similarity_score < 50) OR
+      -- High distance with name match
+      (distance_meters > 30 AND name_similarity_score > 80)
+  )
+ORDER BY composite_score ASC
+LIMIT 500;
+
+-- ============================================================================
+-- PERFORMANCE OPTIMIZATION: Create spatial index
+-- ============================================================================
+
+-- Create clustering keys for better query performance
+ALTER TABLE poi_table CLUSTER BY (LINEAR(ST_X(place_geometry), ST_Y(place_geometry)));
+
+-- If your Snowflake account supports search optimization:
+-- ALTER TABLE poi_table ADD SEARCH OPTIMIZATION ON EQUALITY(place_id, building_id);
+-- ALTER TABLE poi_table ADD SEARCH OPTIMIZATION ON GEO(place_geometry);
+
+-- ============================================================================
+-- DATA QUALITY CHECKS
+-- ============================================================================
+
+-- Check for duplicate place_ids (shouldn't happen with ROW_NUMBER approach)
+SELECT 
+    place_id,
+    COUNT(*) AS occurrences
+FROM poi_table
+GROUP BY place_id
+HAVING COUNT(*) > 1;
+
+-- Check for NULL geometries
+SELECT 
+    COUNT(*) AS null_place_geometries
+FROM poi_table
+WHERE place_geometry IS NULL;
+
+-- Check distribution of match types
+SELECT 
+    CASE 
+        WHEN building_id IS NULL THEN 'No Match'
+        WHEN is_contained THEN 'Contained'
+        WHEN distance_meters <= 5 THEN 'Adjacent (0-5m)'
+        WHEN distance_meters <= 15 THEN 'Nearby (5-15m)'
+        WHEN distance_meters <= 30 THEN 'Close (15-30m)'
+        ELSE 'Distant (>30m)'
+    END AS match_type,
+    COUNT(*) AS count,
+    ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 2) AS percentage
+FROM poi_table
+GROUP BY match_type
+ORDER BY count DESC;


### PR DESCRIPTION
Create a POI table by spatially matching Overture Maps places to buildings, using a composite score of fuzzy name similarity and spatial proximity to select the best building match for each place.

The user requested a solution that handles multiple overlapping building polygons by combining fuzzy name matching and distance to nearest to pick the single best match for each place. This PR implements a robust scoring and ranking mechanism to achieve this, including comprehensive documentation, quick-start guides, and alternative matching strategies.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8e95dd0-83db-4732-b95c-7ee8113199ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8e95dd0-83db-4732-b95c-7ee8113199ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

